### PR TITLE
enabled support for loadBalancerIP

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -6,6 +6,11 @@ metadata:
     {{- include "openspeedtest.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+{{- if eq .Values.service.type "LoadBalancer" }}
+{{- if hasKey .Values.service "loadBalancerIP" }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP}}
+{{- end }}
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/values.yaml
+++ b/values.yaml
@@ -38,6 +38,7 @@ securityContext: {}
 
 service:
   type: LoadBalancer
+  #loadBalancerIP: 10.10.10.10
   port: 3000
 
 ingress:


### PR DESCRIPTION
In several platforms, when using a service of type Load Balancer, it is interesting to allow the user to specify the actual Load Balancer IP to be used. This PR enables that option to be passed through the values of the chart.