### PR TITLE
Add service.annotations support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,4 +14,4 @@ name: openspeedtest
 sources:
 - https://github.com/openspeedtest/Helm-chart
 type: application
-version: 0.1.2
+version: 0.1.3

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "openspeedtest.fullname" . }}
   labels:
     {{- include "openspeedtest.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
 {{- if eq .Values.service.type "LoadBalancer" }}

--- a/values.yaml
+++ b/values.yaml
@@ -41,6 +41,8 @@ service:
   type: LoadBalancer
   #loadBalancerIP: 10.10.10.10
   port: 3000
+  annotations: {}
+    # cloud.google.com/neg: '{"ingress": true}'
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary

Add optional `service.annotations` rendering to `templates/service.yaml`, mirroring the existing pattern used by `serviceAccount.annotations` and `podAnnotations`. Bumps chart version 0.1.2 → 0.1.3.

## Motivation

The Service rendered by this chart has no way to receive annotations, which blocks several real-world deployment patterns. The case that drove this: deploying the chart on GKE with a GCE Ingress fronting a ClusterIP Service requires the `cloud.google.com/neg: '{\"ingress\": true}'` annotation for container-native load balancing. Without `service.annotations`, the Ingress fails to translate with: `service \"X\" is type \"ClusterIP\", expected \"NodePort\" or \"LoadBalancer\" when not using NEGs`.

Other use cases: AWS NLB target-type annotations, MetalLB shared-IP annotations, Linkerd/Istio mesh annotations, internal-LB hints for cloud LBs.

## Changes

- `templates/service.yaml` — render `metadata.annotations` from `.Values.service.annotations` when non-empty (guarded by `with`).
- `values.yaml` — add `service.annotations: {}` default with a commented example.
- `Chart.yaml` — bump `version: 0.1.2` → `0.1.3`.

Backward compatible: the block is omitted when the map is empty, so existing installs produce identical YAML.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` with no annotations produces no `annotations:` block on the Service (identical to current behavior)
- [x] `helm template` with `service.annotations.cloud.google.com/neg: '{"ingress": true}'` renders the annotation correctly
- [x] End-to-end verified on a real GKE cluster: chart-deployed Service now carries the NEG annotation and the GCE Ingress translates successfully