### PR TITLE
Add optional Gateway API HTTPRoute template

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,4 +14,4 @@ name: openspeedtest
 sources:
 - https://github.com/openspeedtest/Helm-chart
 type: application
-version: 0.1.2
+version: 0.2.0

--- a/templates/httproute.yaml
+++ b/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "openspeedtest.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "openspeedtest.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+      {{- with .Values.gateway.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -58,6 +58,27 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+gateway:
+  # Render a gateway.networking.k8s.io/v1 HTTPRoute that attaches to an
+  # existing Gateway and points at this chart's Service. Disabled by default.
+  enabled: false
+  annotations: {}
+  # parentRefs binds the HTTPRoute to an existing Gateway. At least one is
+  # required when enabled. `namespace` and `sectionName` are optional.
+  parentRefs: []
+    # - name: my-gateway
+    #   namespace: gateway
+    #   sectionName: https
+  # hostnames restricts the route to specific hosts. When empty, the route
+  # matches every hostname the parent Gateway accepts.
+  hostnames: []
+    # - chart-example.local
+  # matches is optional; when empty the rule applies to all paths.
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Summary

Adds an optional `templates/httproute.yaml` that renders a `gateway.networking.k8s.io/v1` HTTPRoute when `gateway.enabled: true`. Backend always points at this chart's Service (matching how `ingress.yaml` references the Service).

Bumps chart version 0.1.2 → 0.2.0 because this introduces a new templated resource (minor bump, not patch).

## Motivation

Many GKE / mesh / Kubernetes-1.30+ setups use Gateway API instead of Ingress. The chart already supports `ingress` but had no Gateway API equivalent, forcing users to apply a sibling `HTTPRoute` manifest separately. With this change, a single `helm install` can attach the openspeedtest Service to a pre-existing shared Gateway.

Example values:

```yaml
gateway:
  enabled: true
  parentRefs:
    - name: shared-gateway
      namespace: gateway
      sectionName: https
  hostnames:
    - speedtest.example.com
```

## Design notes

- **Disabled by default** — `gateway.enabled: false`, so existing installs render no change.
- **No Gateway resource is created** — only the HTTPRoute. Gateways are typically shared infrastructure provisioned outside the chart.
- **Backend is the chart's own Service** — same `{{ include "openspeedtest.fullname" . }}` pattern used by `ingress.yaml`, so multiple route types stay consistent.
- **`hostnames`** is optional. When empty, the route matches every hostname the parent Gateway accepts.
- **`matches`** is optional. When empty, the rule matches every path.
- **`parentRefs`** is required when enabled (no sensible default).

## Changes

- `templates/httproute.yaml` — new template guarded by `.Values.gateway.enabled`.
- `values.yaml` — add `gateway:` section after `ingress:` with the same disabled-by-default + commented-example style.
- `Chart.yaml` — bump version `0.1.2` → `0.2.0`.

## Test plan

- [x] `helm lint` passes.
- [x] `helm template` with `gateway.enabled: false` (default): no HTTPRoute is emitted.
- [x] `helm template` with `gateway.enabled: true` + `parentRefs`/`hostnames`/`matches`: HTTPRoute renders matching the spec.
- [x] `helm template` with `gateway.enabled: true` + `matches: []`: HTTPRoute renders without a `matches` block (catch-all route).
- [x] End-to-end verified on a real GKE cluster: chart-deployed HTTPRoute attaches to a Gateway (rilb-gateway) and routes traffic to the chart's Service.